### PR TITLE
Fix compilation on mingw target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("cargo:rustc-link-lib=Iphlpapi");
+    println!("cargo:rustc-link-lib=iphlpapi");
 }


### PR DESCRIPTION
The crate failed to build under Linux (probably because of case-sensitive fs?)