### PR TITLE
Upgrade to error-chain 0.11.0 and remove backtrace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "liranringel/ipconfig" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "^0.3.4"
-error-chain = "0.8"
+error-chain = { version = "0.11.0", default-features = false }
 widestring = "^0.2.2"
 socket2 = "^0.3.1"
 winreg = "^0.5.0"


### PR DESCRIPTION
Some applications that use ipconfig don't want automatic backtraces
in errors. The successor to error-chain, the failure crate, will not
have backtraces enabled by default. Accordingly, turn off backtraces.

While doing so, upgrade to error-chain 0.11.0.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>