### PR TITLE
Fixed panic on get_search_list with missing SearchList subkey

### DIFF
--- a/src/computer.rs
+++ b/src/computer.rs
@@ -49,9 +49,13 @@ pub fn get_search_list() -> Result<Vec<String>> {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let params_key = hklm.open_subkey_with_flags(TCPIP_PARAMETERS_KEY_PATH,
                                                  KEY_READ)?;
-    let search_list: String = params_key.get_value("SearchList")?;
-    let search_list: Vec<String> = search_list.split(',').map(|s| s.to_string()).collect();
-    Ok(search_list)
+    let search_list: ::std::io::Result<String> = params_key.get_value("SearchList");
+    if let Ok(search_list) = search_list {
+        let search_list: Vec<String> = search_list.split(',').map(|s| s.to_string()).collect();
+        Ok(search_list)
+    } else {
+        Ok(vec![])
+    }
 }
 
 /// Returns the computer domain name (if any).


### PR DESCRIPTION
In case the `SearchList` subkey does not exist, return an empty `Vec<String>`. This still returns an `Ok` result, since it seems to be a valid state for the registry when nothing is in the DNS search list (and possibly, nothing has ever been there).

Fixes issue #15.