### PR TITLE
Version 0.1.7 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ipconfig"
-version = "0.1.6"  # Remember to also update the html_root_url in lib.rs and the documentation links here and in README.md
+version = "0.1.7"  # Remember to also update the html_root_url in lib.rs and the documentation links here and in README.md
 authors = ["Liran Ringel <liranringel@gmail.com>"]
 description = "Get network adapters information and network configuration for windows."
 license = "MIT/Apache-2.0"
 keywords = ["ipconfig", "network", "adapter", "interface", "windows"]
 repository = "https://github.com/liranringel/ipconfig"
 homepage = "https://github.com/liranringel/ipconfig"
-documentation = "https://docs.rs/ipconfig/0.1.6/x86_64-pc-windows-msvc/ipconfig/"
+documentation = "https://docs.rs/ipconfig/0.1.7/x86_64-pc-windows-msvc/ipconfig/"
 readme = "README.md"
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/tiwjo6q4eete0nmh/branch/master?svg=true)](https://ci.appveyor.com/project/liran-ringel/ipconfig/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/ipconfig.svg)](https://crates.io/crates/ipconfig)
 
-[Documentation](https://docs.rs/ipconfig/0.1.6/x86_64-pc-windows-msvc/ipconfig/)
+[Documentation](https://docs.rs/ipconfig/0.1.7/x86_64-pc-windows-msvc/ipconfig/)
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```
 
 #![cfg(windows)]
-#![doc(html_root_url = "https://docs.rs/ipconfig/0.1.6/x86_64-pc-windows-msvc/ipconfig/")]
+#![doc(html_root_url = "https://docs.rs/ipconfig/0.1.7/x86_64-pc-windows-msvc/ipconfig/")]
 
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
I'd like a new release to be made with the fix from #16, so that I can open a PR on [trust-dns](https://github.com/bluejekyll/trust-dns/blob/master/resolver/Cargo.toml#L80) to update. :)

This is where I encountered the panic described in #15.