### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "liranringel/ipconfig" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "^0.3.4"
-error-chain = "0.8"
-widestring = "^0.2.2"
+error-chain = "0.12"
+widestring = "^0.4"
 socket2 = "^0.3.1"
-winreg = "^0.5.0"
+winreg = "^0.6.0"


### PR DESCRIPTION
This updates both the error-chain and widestring dependency to the latest version.