### PR TITLE
replace error-chain with failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "liranringel/ipconfig" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "^0.3.4"
-error-chain = "0.8"
 widestring = "^0.2.2"
 socket2 = "^0.3.1"
 winreg = "^0.5.0"
+failure = "0.1"

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -58,7 +58,7 @@ pub fn get_adapters() -> Result<Vec<Adapter>> {
         assert!(result != ERROR_SUCCESS);
 
         if result != ERROR_BUFFER_OVERFLOW {
-            bail!(ErrorKind::Os(result));
+            return Err(ErrorKind::Os(result).into());
         }
 
         let mut adapters_addresses_buffer: Vec<u8> = vec![0; buf_len as usize];
@@ -66,7 +66,7 @@ pub fn get_adapters() -> Result<Vec<Adapter>> {
         let result = GetAdaptersAddresses(AF_UNSPEC as u32, 0, std::ptr::null_mut(), adapter_addresses_ptr, &mut buf_len as *mut ULONG);
 
         if result != ERROR_SUCCESS {
-            bail!(ErrorKind::Os(result));
+            return Err(ErrorKind::Os(result).into());
         }
 
         let mut adapters = vec![];

--- a/src/computer.rs
+++ b/src/computer.rs
@@ -8,8 +8,7 @@ use winreg::enums::KEY_READ;
 use winapi::shared::minwindef::HKEY;
 use winreg::enums::HKEY_LOCAL_MACHINE;
 
-use error::*;
-
+use error::Result;
 
 /// Returns a value from the registry, and returns a default if it doesn't exist.
 fn get_value<T: FromRegValue>(predef: HKEY,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,9 @@
-error_chain! {
-    foreign_links {
-        Utf8(::std::str::Utf8Error);
-        FromUtf16(::std::string::FromUtf16Error);
-        Io(::std::io::Error);
-    }
+use failure::Error;
 
-    errors {
-        Os(error: u32) {
-            description("Win32 error occurred")
-            display("Win32 error occurred: {}", error)
-        }
-    }
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "Win32 error occurred: {}", _0)]
+    Os(u32),
 }
+
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 #![doc(html_root_url = "https://docs.rs/ipconfig/0.1.7/x86_64-pc-windows-msvc/ipconfig/")]
 
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 extern crate winapi;
 extern crate widestring;
 extern crate socket2;


### PR DESCRIPTION
Error chain is going to be deprecated: https://github.com/rust-lang-nursery/failure/issues/181
failure is a preferable replacement for it.