### PR TITLE
Add link speeds, interface type and status

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -10,6 +10,45 @@ use error::*;
 
 use bindings::*;
 
+/// Represent an operational status of the adapter
+/// See IP_ADAPTER_ADDRESSES docs for more details
+#[derive(Debug, Clone, Copy)]
+pub enum OperStatus {
+    IfOperStatusUp = 1,
+    IfOperStatusDown = 2,
+    IfOperStatusTesting = 3,
+    IfOperStatusUnknown = 4,
+    IfOperStatusDormant = 5,
+    IfOperStatusNotPresent = 6,
+    IfOperStatusLowerLayerDown = 7,
+}
+
+/// Represent an interface type
+/// See IANA docs on iftype for more details
+/// https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
+/// Note that we only support a subset of the IANA interface
+/// types and in case the adapter has an unsupported type,
+/// `IfType::Unsupported` is used. `IfType::Other`
+/// is different from `IfType::Unsupported`, as the former
+/// one is defined by the IANA itself.
+#[derive(Debug, Clone, Copy)]
+pub enum IfType {
+    Other = 1,
+    EthernetCsmacd = 6,
+    Iso88025Tokenring = 9,
+    Ppp = 23,
+    SoftwareLoopback = 24,
+    Atm = 37,
+    Ieee80211 = 71,
+    Tunnel = 131,
+    Ieee1394 = 144,
+    Unsupported,
+    /// This enum may grow additional variants, so this makes sure clients
+    /// don't count on exhaustive matching. (Otherwise, adding a new variant
+    /// could break existing code.)
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
 
 /// Represent an adapter.
 #[derive(Debug)]
@@ -20,6 +59,10 @@ pub struct Adapter {
     description: String,
     friendly_name: String,
     physical_address: Option<Vec<u8>>,
+    receive_link_speed: u64,
+    transmit_link_speed: u64,
+    oper_status: OperStatus,
+    if_type: IfType,
 }
 
 impl Adapter {
@@ -46,6 +89,26 @@ impl Adapter {
     /// Get the adapter's physical (MAC) address
     pub fn physical_address(&self) -> &Option<Vec<u8>> {
         &self.physical_address
+    }
+
+    /// Get the adapter Recieve Link Speed (bits per second)
+    pub fn receive_link_speed(&self) -> u64 {
+        self.receive_link_speed
+    }
+
+    /// Get the Trasnmit Link Speed (bits per second)
+    pub fn transmit_link_speed(&self) -> u64 {
+        self.transmit_link_speed
+    }
+
+    /// Check if the adapter is up (OperStatus is IfOperStatusUp)
+    pub fn oper_status(&self) -> OperStatus {
+        self.oper_status
+    }
+
+    /// Get the interface type
+    pub fn if_type(&self) -> IfType {
+        self.if_type
     }
 }
 
@@ -84,6 +147,30 @@ unsafe fn get_adapter(adapter_addresses_ptr: PIP_ADAPTER_ADDRESSES) -> Result<Ad
     let adapter_name = CStr::from_ptr(adapter_addresses.AdapterName).to_str()?.to_owned();
     let dns_servers = get_dns_servers(adapter_addresses.FirstDnsServerAddress)?;
     let unicast_addresses = get_unicast_addresses(adapter_addresses.FirstUnicastAddress)?;
+    let receive_link_speed: u64 = adapter_addresses.ReceiveLinkSpeed;
+    let transmit_link_speed: u64 = adapter_addresses.TransmitLinkSpeed;
+    let oper_status = match adapter_addresses.OperStatus {
+            1 => OperStatus::IfOperStatusUp,
+            2 => OperStatus::IfOperStatusDown,
+            3 => OperStatus::IfOperStatusTesting,
+            4 => OperStatus::IfOperStatusUnknown,
+            5 => OperStatus::IfOperStatusDormant,
+            6 => OperStatus::IfOperStatusNotPresent,
+            7 => OperStatus::IfOperStatusLowerLayerDown,
+            v => { panic!("unexpected OperStatus value: {}", v); }
+        };
+    let if_type = match adapter_addresses.IfType {
+        1 => IfType::Other,
+        6 => IfType::EthernetCsmacd,
+        9 => IfType::Iso88025Tokenring,
+        23 => IfType::Ppp,
+        24 => IfType::SoftwareLoopback,
+        37 => IfType::Atm,
+        71 => IfType::Ieee80211,
+        131 => IfType::Tunnel,
+        144 => IfType::Ieee1394,
+        _ => IfType::Unsupported,
+    };
 
     let description = WideCString::from_ptr_str(adapter_addresses.Description).to_string()?;
     let friendly_name = WideCString::from_ptr_str(adapter_addresses.FriendlyName).to_string()?;
@@ -99,6 +186,10 @@ unsafe fn get_adapter(adapter_addresses_ptr: PIP_ADAPTER_ADDRESSES) -> Result<Ad
         description: description,
         friendly_name: friendly_name,
         physical_address: physical_address,
+        receive_link_speed: receive_link_speed,
+        transmit_link_speed: transmit_link_speed,
+        oper_status: oper_status,
+        if_type: if_type,
     })
 }
 


### PR DESCRIPTION
Just extracting some additional info from the same structure returned by `GetAdaptersAddresses`.