### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,11 +25,7 @@ impl std::fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "ipconfig error"
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.kind {
             ErrorKind::Utf8(err) => Some(err),
             ErrorKind::FromUtf16(err) => Some(err),


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon. Error::cause has already been deprecated since 1.33.0.

This PR:
- Removes the implementations of `description`
- Replace deprecated `cause` with `source`

Related PR: https://github.com/rust-lang/rust/pull/66919