### PR TITLE
Bump winreg to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ appveyor = { repository = "liranringel/ipconfig" }
 winapi = "^0.3.4"
 widestring = "^0.4"
 socket2 = "^0.3.1"
-winreg = "^0.6.0"
+winreg = "^0.7.0"


### PR DESCRIPTION
I don't have a windows computer to test this on but winreg 0.7 shouldn't have introduced any breaking changes for this project https://github.com/gentoo90/winreg-rs/compare/v0.6.2...v0.7.0