### PR TITLE
Expose IPv4 & IPv6 adapter metrics to allow priority sorting

### DIFF
--- a/examples/priority_list.rs
+++ b/examples/priority_list.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let mut adapters = ipconfig::get_adapters().unwrap();
+    adapters.sort_by(|ip1, ip2| ip1.ipv4_metric().cmp(&ip2.ipv4_metric()));
+    for adapter in adapters {
+        println!(
+            "{}: IfType: {:?}  IPs: {:?} - IPv4 metric: {} IPv6 metric: {}",
+            adapter.friendly_name(),
+            adapter.if_type(),
+            adapter.ip_addresses(),
+            adapter.ipv4_metric(),
+            adapter.ipv6_metric()
+        )
+    }
+}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -70,6 +70,8 @@ pub struct Adapter {
     oper_status: OperStatus,
     if_type: IfType,
     ipv6_if_index: u32,
+    ipv4_metric: u32,
+    ipv6_metric: u32,
 }
 
 impl Adapter {
@@ -135,6 +137,15 @@ impl Adapter {
     pub fn ipv6_if_index(&self) -> u32 {
         self.ipv6_if_index
     }
+
+    /// Returns the metric used to compute route preference for IPv4
+    pub fn ipv4_metric(&self) -> u32 {
+        self.ipv4_metric
+    }
+    /// Returns the metric used to compute route preference for IPv6
+    pub fn ipv6_metric(&self) -> u32 {
+        self.ipv6_metric
+    }
 }
 
 /// Get all the network adapters on this machine.
@@ -165,7 +176,8 @@ pub fn get_adapters() -> Result<Vec<Adapter>> {
         }
 
         let mut adapters = vec![];
-        let mut adapter_addresses_ptr = adapters_addresses_buffer.as_mut_ptr() as PIP_ADAPTER_ADDRESSES;
+        let mut adapter_addresses_ptr =
+            adapters_addresses_buffer.as_mut_ptr() as PIP_ADAPTER_ADDRESSES;
 
         while !adapter_addresses_ptr.is_null() {
             adapters.push(get_adapter(adapter_addresses_ptr)?);
@@ -187,6 +199,8 @@ unsafe fn get_adapter(adapter_addresses_ptr: PIP_ADAPTER_ADDRESSES) -> Result<Ad
     let unicast_addresses = get_unicast_addresses(adapter_addresses.FirstUnicastAddress)?;
     let receive_link_speed: u64 = adapter_addresses.ReceiveLinkSpeed;
     let transmit_link_speed: u64 = adapter_addresses.TransmitLinkSpeed;
+    let ipv4_metric = adapter_addresses.Ipv4Metric;
+    let ipv6_metric = adapter_addresses.Ipv6Metric;
     let oper_status = match adapter_addresses.OperStatus {
         1 => OperStatus::IfOperStatusUp,
         2 => OperStatus::IfOperStatusDown,
@@ -237,6 +251,8 @@ unsafe fn get_adapter(adapter_addresses_ptr: PIP_ADAPTER_ADDRESSES) -> Result<Ad
         oper_status,
         if_type,
         ipv6_if_index,
+        ipv4_metric,
+        ipv6_metric,
     })
 }
 


### PR DESCRIPTION
This lets users of the library know what the system's priority is per-adapter.

We had reason to want to sort network adapters by how the system prioritizes them, these changes let that information be available to do so.