### PR TITLE
hide computer mod behind a feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,12 @@ edition = "2018"
 [badges]
 appveyor = { repository = "liranringel/ipconfig" }
 
+[features]
+default = ["computer"]
+computer = ["winreg"]
+
 [target.'cfg(windows)'.dependencies]
 winapi = "^0.3.4"
 widestring = "^0.5"
 socket2 = "^0.4.0"
-winreg = "^0.7.0"
+winreg = { version = "^0.7.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ extern crate widestring;
 extern crate winapi;
 mod adapter;
 mod bindings;
+
+#[cfg(feature = "computer")]
 pub mod computer;
 pub mod error;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,13 @@
 use ipconfig;
 
 #[test]
-fn no_error() {
+fn no_error_adapters() {
     println!("Adapters: {:#?}", ipconfig::get_adapters().unwrap());
+}
+
+#[cfg(feature = "computer")]
+#[test]
+fn no_error_computer() {
     println!(
         "Search list: {:#?}",
         ipconfig::computer::get_search_list().unwrap()


### PR DESCRIPTION
Reading Registry values in some environments like UWP is restricted. By hiding `computer` mod behind a feature gate, users can opt out of these features while normal users will not spot any difference.