### PR TITLE
fix calling convention for binding functions

### DIFF
--- a/src/bindings/win32.rs
+++ b/src/bindings/win32.rs
@@ -2579,8 +2579,7 @@ impl Clone for _IP_ADAPTER_ADDRESSES_LH {
 }
 pub type IP_ADAPTER_ADDRESSES_LH = _IP_ADAPTER_ADDRESSES_LH;
 pub type PIP_ADAPTER_ADDRESSES = *mut IP_ADAPTER_ADDRESSES_LH;
-extern "stdcall" {
-    #[link_name = "\u{1}_GetAdaptersAddresses@20"]
+extern "system" {
     pub fn GetAdaptersAddresses(
         Family: ULONG,
         Flags: ULONG,

--- a/src/bindings/win64.rs
+++ b/src/bindings/win64.rs
@@ -2579,7 +2579,7 @@ impl Clone for _IP_ADAPTER_ADDRESSES_LH {
 }
 pub type IP_ADAPTER_ADDRESSES_LH = _IP_ADAPTER_ADDRESSES_LH;
 pub type PIP_ADAPTER_ADDRESSES = *mut IP_ADAPTER_ADDRESSES_LH;
-extern "C" {
+extern "system" {
     pub fn GetAdaptersAddresses(
         Family: ULONG,
         Flags: ULONG,


### PR DESCRIPTION
Windows APIs have different name mangling rules on different platforms, such as x86 and ARM. The `extern "system"` decorator will instruct rustc to choose a suitable calling convention based on the target platform.

Also see how `winapi-rs` handles this function:

https://github.com/retep998/winapi-rs/blob/5b1829956ef645f3c2f8236ba18bb198ca4c2468/src/um/iphlpapi.rs#L337