### PR TITLE
Updated winreg to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ computer = ["winreg"]
 winapi = "^0.3.4"
 widestring = "^0.5"
 socket2 = "^0.4.0"
-winreg = { version = "^0.7.0", optional = true }
+winreg = { version = "^0.10.1", optional = true }


### PR DESCRIPTION
This is a PR to update to latest `winreg`. In another project I use there is a version conflict as this repo uses an older version of `winreg`. It does not break any compatibility from what I can see and the tests works just fine 👍 

EDIT: Or release current main which allows me to use `default-features = false` to skip the `winreg` dependency