### PR TITLE
windows-sys 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["computer"]
 computer = ["winreg"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
+windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
 widestring = "1.0.2"
 socket2 = "0.5.1"
-winreg = { version = "0.50.0", optional = true }
+winreg = { version = "0.52.0", optional = true }


### PR DESCRIPTION
Pseudo-blocked on https://github.com/gentoo90/winreg-rs/pull/63 and socket2's unreleased (yet committed) update to windows-sys 0.52.