### PR TITLE
feat: bump version to 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ipconfig"
-version = "0.3.2"  # Remember to also update the html_root_url in lib.rs and the documentation links here and in README.md
+version = "0.3.3"  # Remember to also update the html_root_url in lib.rs and the documentation links here and in README.md
 authors = ["Liran Ringel <liranringel@gmail.com>"]
 description = "Get network adapters information and network configuration for windows."
 license = "MIT/Apache-2.0"
 keywords = ["ipconfig", "network", "adapter", "interface", "windows"]
 repository = "https://github.com/liranringel/ipconfig"
 homepage = "https://github.com/liranringel/ipconfig"
-documentation = "https://docs.rs/ipconfig/0.3.2/x86_64-pc-windows-msvc/ipconfig/"
+documentation = "https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ipconfig"
-version = "0.3.3"  # Remember to also update the html_root_url in lib.rs and the documentation links here and in README.md
+version = "0.3.3"
 authors = ["Liran Ringel <liranringel@gmail.com>"]
 description = "Get network adapters information and network configuration for windows."
 license = "MIT/Apache-2.0"
 keywords = ["ipconfig", "network", "adapter", "interface", "windows"]
 repository = "https://github.com/liranringel/ipconfig"
 homepage = "https://github.com/liranringel/ipconfig"
-documentation = "https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/"
+documentation = "https://docs.rs/ipconfig/latest/x86_64-pc-windows-msvc/ipconfig/"
 readme = "README.md"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/tiwjo6q4eete0nmh/branch/master?svg=true)](https://ci.appveyor.com/project/liran-ringel/ipconfig/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/ipconfig.svg)](https://crates.io/crates/ipconfig)
 
-[Documentation](https://docs.rs/ipconfig/0.3.2/x86_64-pc-windows-msvc/ipconfig/)
+[Documentation](https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/tiwjo6q4eete0nmh/branch/master?svg=true)](https://ci.appveyor.com/project/liran-ringel/ipconfig/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/ipconfig.svg)](https://crates.io/crates/ipconfig)
 
-[Documentation](https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/)
+[Documentation](https://docs.rs/ipconfig/latest/x86_64-pc-windows-msvc/ipconfig/)
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```
 
 #![cfg(windows)]
-#![doc(html_root_url = "https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/")]
+#![doc(html_root_url = "https://docs.rs/ipconfig/latest/x86_64-pc-windows-msvc/ipconfig/")]
 
 extern crate widestring;
 extern crate windows_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```
 
 #![cfg(windows)]
-#![doc(html_root_url = "https://docs.rs/ipconfig/0.3.2/x86_64-pc-windows-msvc/ipconfig/")]
+#![doc(html_root_url = "https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/")]
 
 extern crate widestring;
 extern crate windows_sys;


### PR DESCRIPTION
To make use of the new updated dependency tree for `socket2 0.6.0`.