### PR TITLE
`windows-sys 0.59`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["computer"]
 computer = ["winreg"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
 widestring = "1.0.2"
 socket2 = "0.6.0"
-winreg = { version = "0.50.0", optional = true }
+winreg = { version = "0.55.0", optional = true }


### PR DESCRIPTION
This is the same version used by `socket2 0.6` and `winreg 0.55` (also updated to).