### PR TITLE
feat: update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["computer"]
 computer = ["winreg"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
-widestring = "1.0.2"
+windows-sys = { version = "0.61.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_Registry"] }
+widestring = "1.2.0"
 socket2 = "0.6.0"
-winreg = { version = "0.50.0", optional = true }
+winreg = { version = "0.55.0", optional = true }


### PR DESCRIPTION
Updates all deps (but `socket2`) to latest requested as per https://github.com/liranringel/ipconfig/pull/60#issuecomment-3262829756.
I'm making this PR from a mac computer, so I can't manually run the tests.