### PR TITLE
Remove AppVeyor build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **Get network adapters information and network configuration for windows.**
 
-[![Build status](https://ci.appveyor.com/api/projects/status/tiwjo6q4eete0nmh/branch/master?svg=true)](https://ci.appveyor.com/project/liran-ringel/ipconfig/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/ipconfig.svg)](https://crates.io/crates/ipconfig)
 
 [Documentation](https://docs.rs/ipconfig/0.3.3/x86_64-pc-windows-msvc/ipconfig/)


### PR DESCRIPTION
Removed AppVeyor build status badge from README.

The AppVeyor CI configuration was removed in https://github.com/liranringel/ipconfig/pull/70